### PR TITLE
Added support of optional "linkText" attribute for <xsd:xmlEntityReference> elements

### DIFF
--- a/etc/Schemas/XsdDocumentation.xsd
+++ b/etc/Schemas/XsdDocumentation.xsd
@@ -22,13 +22,24 @@
     </xs:annotation>
   </xs:element>
 
-  <xs:element name="xmlEntityReference" type="xmlEntityUri">
+  <xs:element name="xmlEntityReference">
     <xs:annotation>
       <xs:documentation>
         This element can be used to create links to XML entities, such as
         elements, attributes, groups or types.
       </xs:documentation>
     </xs:annotation>
+	  <xs:complexType>
+		  <xs:simpleContent>
+			  <xs:extension base="xmlEntityUri">
+				  <xs:attribute name="linkText" type="xs:string" use="optional">
+					  <xs:annotation>
+						  <xs:documentation>The custom text of the link to use instead of topic's title.</xs:documentation>
+					  </xs:annotation>
+				  </xs:attribute>
+			  </xs:extension>
+		  </xs:simpleContent>
+	  </xs:complexType>
   </xs:element>
 
   <xs:element name="examples" type="ddue:namedSectionType">

--- a/src/XsdDocumentation.BuildComponents/XsdResolveLinksComponent.cs
+++ b/src/XsdDocumentation.BuildComponents/XsdResolveLinksComponent.cs
@@ -67,7 +67,7 @@ namespace XsdDocumentation.BuildComponents
             if (nodes == null)
                 return;
 
-            foreach (XmlNode node in nodes)
+            foreach (XmlElement node in nodes)
             {
                 var parentNode = node.ParentNode;
                 var uri = node.InnerText;
@@ -82,8 +82,11 @@ namespace XsdDocumentation.BuildComponents
                     var linkElement = document.CreateElement("ddue", "link", Namespaces.Maml);
                     linkElement.SetAttribute("href", Namespaces.XLink, entry.TopicId);
                     linkElement.SetAttribute("topicType_id", "3272D745-2FFC-48C4-9E9D-CF2B2B784D5F");
-                    linkElement.InnerText = entry.LinkTitle;
-                    parentNode.ReplaceChild(linkElement, node);
+					if (node.HasAttribute("linkText"))
+						linkElement.InnerText = node.GetAttribute("linkText");
+					else
+						linkElement.InnerText = entry.LinkTitle;
+					parentNode.ReplaceChild(linkElement, node);
                 }
             }
         }


### PR DESCRIPTION
Help authors can specify custom text to display for &lt;codeEntityReference&gt;  element, using the "linkText" attribute.  I've added similar feature for &lt;xmlEntityReference&gt; elements.

For example:
&lt;xsd:xmlEntityReference linkText="HTTP Handlers Configuration"&gt;#E/configuration/system.webServer/handlers&lt;/xsd:xmlEntityReference&gt;