### PR TITLE
Make compatible with SHFB 2016.9.17.0

### DIFF
--- a/setup/Product.wxs
+++ b/setup/Product.wxs
@@ -30,7 +30,7 @@
       <DirectorySearch Id="ShfbRootSearch" Path="[%SHFBROOT]">
         <!-- We must set the minimum version number one lower than the actual file we are looking for. -->
         <FileSearch Name="SandcastleBuilderGUI.exe" MinVersion="15.7.25.0"
-                                                    MaxVersion="15.10.10.0"/>
+                                                    MaxVersion="16.9.17.0"/>
       </DirectorySearch>
     </Property>
 

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -17,6 +17,6 @@ using System.Runtime.InteropServices;
 
 internal static class XsdDocMetadata
 {
-    public const string Version = "15.10.10.0";
+    public const string Version = "16.9.17.0";
     public const string Copyright = "Copyright © 2009-2015 Immo Landwerth";
 }


### PR DESCRIPTION
Incorporates part of #16 and makes version number of XSD Doc consistent.

Thansk @cklutz!